### PR TITLE
Improved error handling

### DIFF
--- a/03 - Lab 3 - Backup and Restore/backup/camunda-backup-job.yaml
+++ b/03 - Lab 3 - Backup and Restore/backup/camunda-backup-job.yaml
@@ -18,6 +18,8 @@ spec:
         args:
         - -c
         - |
+          set -e
+
           perform_backup() {
             local service_name=$1
             local service_port=$2
@@ -25,14 +27,14 @@ spec:
             local fail_count=0
 
             # Perform backup
-            curl -X POST "http://camunda-$service_name:$service_port$path_prefix/actuator/backups" \
+            curl --fail -X POST "http://camunda-$service_name:$service_port$path_prefix/actuator/backups" \
               -H 'Content-Type: application/json' \
               -d "{\"backupId\": \"$BACKUP_TIME_ID\"}"
             sleep 5
 
             # Validate backup
             while true; do
-              response=$(curl -s "http://camunda-$service_name:$service_port$path_prefix/actuator/backups/$BACKUP_TIME_ID")
+              response=$(curl --fail -s "http://camunda-$service_name:$service_port$path_prefix/actuator/backups/$BACKUP_TIME_ID")
               echo "$response"
               if echo "$response" | grep -q '"COMPLETED"'; then
                 echo "Backup for $service_name completed successfully."

--- a/03 - Lab 3 - Backup and Restore/backup/camunda-backup-job.yaml
+++ b/03 - Lab 3 - Backup and Restore/backup/camunda-backup-job.yaml
@@ -18,6 +18,7 @@ spec:
         args:
         - -c
         - |
+          #!/bin/sh
           set -e
 
           perform_backup() {

--- a/03 - Lab 3 - Backup and Restore/backup/create-backupId-as-secret.sh
+++ b/03 - Lab 3 - Backup and Restore/backup/create-backupId-as-secret.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 # Generate the backupTimeId based on the current date and time
@@ -7,7 +6,7 @@ backupTimeId=$(date +"%Y%m%d%H%M%S")
 # Check if the secret exists
 kubectl get secret backup-timeid >/dev/null 2>&1
 
-if [ $? -eq 0 ]; then
+if [ "$(kubectl get secret backup-timeid >/dev/null 2>&1)"]; then
     # Secret exists, update it
     kubectl create secret generic backup-timeid --from-literal=backupTimeId=$backupTimeId --dry-run=client -o yaml | kubectl apply -f -
     echo "Updated secret with backupTimeId: $backupTimeId"

--- a/03 - Lab 3 - Backup and Restore/backup/create-backupId-as-secret.sh
+++ b/03 - Lab 3 - Backup and Restore/backup/create-backupId-as-secret.sh
@@ -6,12 +6,12 @@ backupTimeId=$(date +"%Y%m%d%H%M%S")
 # Check if the secret exists
 kubectl get secret backup-timeid >/dev/null 2>&1
 
-if [ "$(kubectl get secret backup-timeid >/dev/null 2>&1)"]; then
+if kubectl get secret backup-timeid >/dev/null 2>&1; then
     # Secret exists, update it
-    kubectl create secret generic backup-timeid --from-literal=backupTimeId=$backupTimeId --dry-run=client -o yaml | kubectl apply -f -
+    kubectl create secret generic backup-timeid --from-literal=backupTimeId="$backupTimeId" --dry-run=client -o yaml | kubectl apply -f -
     echo "Updated secret with backupTimeId: $backupTimeId"
 else
     # Secret does not exist, create it
-    kubectl create secret generic backup-timeid --from-literal=backupTimeId=$backupTimeId
+    kubectl create secret generic backup-timeid --from-literal=backupTimeId="$backupTimeId"
     echo "Created secret with backupTimeId: $backupTimeId"
 fi

--- a/03 - Lab 3 - Backup and Restore/backup/es-create-snapshot-zeebe.yaml
+++ b/03 - Lab 3 - Backup and Restore/backup/es-create-snapshot-zeebe.yaml
@@ -19,6 +19,8 @@ spec:
         - -c
         - |
           #!/bin/sh
+          set -e
+
           # Define repository
           repository="zeebe-backup"
 
@@ -29,7 +31,7 @@ spec:
           elasticsearch_endpoint="http://camunda-elasticsearch:9200"
 
           # Create the snapshot
-          curl -X PUT "$elasticsearch_endpoint/_snapshot/$repository/$snapshot_name" -H 'Content-Type: application/json' -d '
+          curl --fail -X PUT "$elasticsearch_endpoint/_snapshot/$repository/$snapshot_name" -H 'Content-Type: application/json' -d '
           {
              "indices": "zeebe-record*",
              "feature_states": ["none"]

--- a/03 - Lab 3 - Backup and Restore/backup/zeebe-backup-job.yaml
+++ b/03 - Lab 3 - Backup and Restore/backup/zeebe-backup-job.yaml
@@ -18,6 +18,7 @@ spec:
         args:
         - -c
         - |
+          #!/bin/bash
           set -e
 
           # Trigger the backup

--- a/03 - Lab 3 - Backup and Restore/backup/zeebe-backup-job.yaml
+++ b/03 - Lab 3 - Backup and Restore/backup/zeebe-backup-job.yaml
@@ -18,8 +18,10 @@ spec:
         args:
         - -c
         - |
+          set -e
+
           # Trigger the backup
-          curl -X POST "http://camunda-zeebe-gateway:9600/actuator/backups" \
+          curl --fail -X POST "http://camunda-zeebe-gateway:9600/actuator/backups" \
             -H 'Content-Type: application/json' \
             -d "{\"backupId\": \"$BACKUP_TIME_ID\"}"
           echo "Backup trigger request sent for ID $BACKUP_TIME_ID"
@@ -28,7 +30,7 @@ spec:
           # Monitor backup status
           fail_count=0
           while true; do
-            response=$(curl -s "http://camunda-zeebe-gateway:9600/actuator/backups/$BACKUP_TIME_ID")
+            response=$(curl --fail -s "http://camunda-zeebe-gateway:9600/actuator/backups/$BACKUP_TIME_ID")
             echo "$response"
             
             # Check if the response includes the specific backupId and state COMPLETED

--- a/03 - Lab 3 - Backup and Restore/backup/zeebe-backup-job.yaml
+++ b/03 - Lab 3 - Backup and Restore/backup/zeebe-backup-job.yaml
@@ -44,7 +44,7 @@ spec:
               echo "Backup $BACKUP_TIME_ID failed or in an unknown state."
               fail_count=$((fail_count+1))
               if [ $fail_count -ge 3 ]; then
-                echo "Failed 3 times, exiting."
+                echo "ERROR: Failed 3 times, exiting." >&2
                 exit 1
               else
                 echo "Retrying, attempt $fail_count of 3."

--- a/03 - Lab 3 - Backup and Restore/backup/zeebe-export-pause.yaml
+++ b/03 - Lab 3 - Backup and Restore/backup/zeebe-export-pause.yaml
@@ -12,6 +12,7 @@ spec:
         args:
         - -c
         - |
+          #!/bin/bash
           curl --fail -X POST "http://camunda-zeebe-gateway:9600/actuator/exporting/pause?soft=true" \
             -H 'Content-Type: application/json' \
             -d '{}'

--- a/03 - Lab 3 - Backup and Restore/backup/zeebe-export-pause.yaml
+++ b/03 - Lab 3 - Backup and Restore/backup/zeebe-export-pause.yaml
@@ -15,5 +15,11 @@ spec:
           curl --fail -X POST "http://camunda-zeebe-gateway:9600/actuator/exporting/pause?soft=true" \
             -H 'Content-Type: application/json' \
             -d '{}'
-          echo "Exporting paused on camunda-zeebe-gateway."
+          success=$?
+          if [ "$success" ]; then
+            echo "Exporting paused on camunda-zeebe-gateway."
+          else
+            echo "ERROR: Could not pause exporting on camunda-zeebe-gateway"  >&2
+            exit 1
+          fi
       restartPolicy: Never

--- a/03 - Lab 3 - Backup and Restore/backup/zeebe-export-pause.yaml
+++ b/03 - Lab 3 - Backup and Restore/backup/zeebe-export-pause.yaml
@@ -12,7 +12,7 @@ spec:
         args:
         - -c
         - |
-          curl -X POST "http://camunda-zeebe-gateway:9600/actuator/exporting/pause?soft=true" \
+          curl --fail -X POST "http://camunda-zeebe-gateway:9600/actuator/exporting/pause?soft=true" \
             -H 'Content-Type: application/json' \
             -d '{}'
           echo "Exporting paused on camunda-zeebe-gateway."

--- a/03 - Lab 3 - Backup and Restore/backup/zeebe-export-resume.yaml
+++ b/03 - Lab 3 - Backup and Restore/backup/zeebe-export-resume.yaml
@@ -15,5 +15,11 @@ spec:
           curl --fail -X POST "http://camunda-zeebe-gateway:9600/actuator/exporting/resume" \
             -H 'Content-Type: application/json' \
             -d '{}'
-          echo "Exporting resumed on camunda-zeebe-gateway."
+          success=$?
+          if [ "$success" ]; then
+            echo "Exporting resumed on camunda-zeebe-gateway."
+          else
+            echo "ERROR: Could not resume exporting on camunda-zeebe-gateway"  >&2
+            exit 1
+          fi
       restartPolicy: Never

--- a/03 - Lab 3 - Backup and Restore/backup/zeebe-export-resume.yaml
+++ b/03 - Lab 3 - Backup and Restore/backup/zeebe-export-resume.yaml
@@ -12,7 +12,7 @@ spec:
         args:
         - -c
         - |
-          curl -X POST "http://camunda-zeebe-gateway:9600/actuator/exporting/resume" \
+          curl --fail -X POST "http://camunda-zeebe-gateway:9600/actuator/exporting/resume" \
             -H 'Content-Type: application/json' \
             -d '{}'
           echo "Exporting resumed on camunda-zeebe-gateway."

--- a/03 - Lab 3 - Backup and Restore/backup/zeebe-export-resume.yaml
+++ b/03 - Lab 3 - Backup and Restore/backup/zeebe-export-resume.yaml
@@ -12,6 +12,7 @@ spec:
         args:
         - -c
         - |
+          #!/bin/bash
           curl --fail -X POST "http://camunda-zeebe-gateway:9600/actuator/exporting/resume" \
             -H 'Content-Type: application/json' \
             -d '{}'

--- a/03 - Lab 3 - Backup and Restore/es-snapshot-minio-job.yaml
+++ b/03 - Lab 3 - Backup and Restore/es-snapshot-minio-job.yaml
@@ -13,6 +13,8 @@ spec:
         - -c
         - |
           #!/bin/sh
+          set -e
+
           # Define bucket names
           buckets="operate-backup optimize-backup tasklist-backup zeebe-backup"
           
@@ -21,7 +23,7 @@ spec:
 
           # Iterate over each bucket name to register it as a snapshot repository without specifying access and secret keys
           for bucket in $buckets; do
-            curl -X PUT "http://camunda-elasticsearch:9200/_snapshot/$bucket" -H 'Content-Type: application/json' -d '
+            curl --fail -X PUT "http://camunda-elasticsearch:9200/_snapshot/$bucket" -H 'Content-Type: application/json' -d '
             {
               "type": "s3",
               "settings": {

--- a/03 - Lab 3 - Backup and Restore/restore/es-delete-all-indices.yaml
+++ b/03 - Lab 3 - Backup and Restore/restore/es-delete-all-indices.yaml
@@ -11,6 +11,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
         - |
+          set -eo pipefail
           # Define Elasticsearch endpoint
           elasticsearch_endpoint="http://camunda-elasticsearch:9200"
           
@@ -20,7 +21,7 @@ spec:
           # Delete each index individually
           for index in $indices; do
             echo "Deleting index: $index"
-            curl -X DELETE "$elasticsearch_endpoint/$index"
+            curl --fail -X DELETE "$elasticsearch_endpoint/$index"
           done
           
           echo "All non-system indices have been deleted."

--- a/03 - Lab 3 - Backup and Restore/restore/es-delete-all-indices.yaml
+++ b/03 - Lab 3 - Backup and Restore/restore/es-delete-all-indices.yaml
@@ -11,12 +11,13 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
         - |
+          #!/bin/sh
           set -eo pipefail
           # Define Elasticsearch endpoint
           elasticsearch_endpoint="http://camunda-elasticsearch:9200"
           
           # List all non-system indices (excluding those starting with .)
-          indices=$(curl -s "$elasticsearch_endpoint/_cat/indices?h=index" | grep -v '^\.')
+          indices=$(curl --fail -s "$elasticsearch_endpoint/_cat/indices?h=index" | grep -v '^\.')
           
           # Delete each index individually
           for index in $indices; do

--- a/03 - Lab 3 - Backup and Restore/restore/es-snapshot-restore-job.yaml
+++ b/03 - Lab 3 - Backup and Restore/restore/es-snapshot-restore-job.yaml
@@ -44,7 +44,8 @@ spec:
                 curl --fail --request POST "$elasticsearch_endpoint/_snapshot/$repository/$snapshot/_restore?wait_for_completion=true"
                 echo "Restore completed for snapshot: $snapshot in repository: $repository"
               else
-                echo "No matching snapshots found in repository $repository."
+                echo "ERROR: No matching snapshots found in repository $repository." >&2
+                exit 1
               fi
             done
           done

--- a/03 - Lab 3 - Backup and Restore/restore/es-snapshot-restore-job.yaml
+++ b/03 - Lab 3 - Backup and Restore/restore/es-snapshot-restore-job.yaml
@@ -19,7 +19,8 @@ spec:
         - -c
         - |
           #!/bin/sh
-          
+          set -eo pipefail
+
           # Define Elasticsearch endpoint
           elasticsearch_endpoint="http://camunda-elasticsearch:9200"
           
@@ -31,7 +32,7 @@ spec:
             echo "Processing repository: $repository"
             
             # Query Elasticsearch for all snapshots in the repository
-            response=$(curl -s "$elasticsearch_endpoint/_snapshot/$repository/_all")
+            response=$(curl --fail -s "$elasticsearch_endpoint/_snapshot/$repository/_all")
 
             # Attempt to extract snapshot names that include the BACKUP_TIME_ID. This uses a simplistic method with grep and cut.
             # Note: This method relies on the snapshot names being in a specific format in the response.
@@ -40,7 +41,7 @@ spec:
                 echo "Found snapshot matching criteria: $snapshot in $repository"
                 # Restore the found snapshot
                 echo "Restoring snapshot: $snapshot in repository: $repository"
-                curl --request POST "$elasticsearch_endpoint/_snapshot/$repository/$snapshot/_restore?wait_for_completion=true"
+                curl --fail --request POST "$elasticsearch_endpoint/_snapshot/$repository/$snapshot/_restore?wait_for_completion=true"
                 echo "Restore completed for snapshot: $snapshot in repository: $repository"
               else
                 echo "No matching snapshots found in repository $repository."

--- a/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-0.yaml
+++ b/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-0.yaml
@@ -11,11 +11,15 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
-          ls -laR /usr/local/zeebe/data
+          ls -lAR /usr/local/zeebe/data
           rm -rf /usr/local/zeebe/data/{*,.*}
           echo "Starting restoration process..."
-          ls -laR /usr/local/zeebe/data
-          /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID} && echo "Restoration complete."
+          if [-z "$(ls -A /usr/local/zeebe/data)"]; then
+            /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID} && echo "Restoration complete."
+          else
+            echo "ERROR: Could not delete zeebe data" >&2
+            exit 1
+          fi
         env:
         - name: ZEEBE_RESTORE_FROM_BACKUP_ID
           valueFrom:

--- a/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-0.yaml
+++ b/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-0.yaml
@@ -11,12 +11,11 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
-          ls -laR /usr/local/zeebe/data;
-          rm -rf /usr/local/zeebe/data/* /usr/local/zeebe/data/.*;
+          ls -laR /usr/local/zeebe/data
+          rm -rf /usr/local/zeebe/data/{*,.*}
           echo "Starting restoration process..."
-          ls -laR /usr/local/zeebe/data;
-          /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID}
-          echo "Restoration complete."
+          ls -laR /usr/local/zeebe/data
+          /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID} && echo "Restoration complete."
         env:
         - name: ZEEBE_RESTORE_FROM_BACKUP_ID
           valueFrom:
@@ -48,9 +47,6 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /usr/local/zeebe/data
-        securityContext:
-          runAsUser: 1000
-          runAsNonRoot: true
       securityContext:
         fsGroup: 1000 
       volumes:

--- a/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-0.yaml
+++ b/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-0.yaml
@@ -11,11 +11,12 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
+          #!/bin/bash
           ls -lAR /usr/local/zeebe/data
           rm -rf /usr/local/zeebe/data/{*,.*}
           echo "Starting restoration process..."
-          if [-z "$(ls -A /usr/local/zeebe/data)"]; then
-            /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID} && echo "Restoration complete."
+          if [ -z "$(ls -A /usr/local/zeebe/data)" ]; then
+            /usr/local/zeebe/bin/restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}" && echo "Restoration complete."
           else
             echo "ERROR: Could not delete zeebe data" >&2
             exit 1

--- a/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-1.yaml
+++ b/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-1.yaml
@@ -11,11 +11,15 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
-          ls -laR /usr/local/zeebe/data
+          ls -lAR /usr/local/zeebe/data
           rm -rf /usr/local/zeebe/data/{*,.*}
           echo "Starting restoration process..."
-          ls -laR /usr/local/zeebe/data
-          /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID} && echo "Restoration complete."
+          if [-z "$(ls -A /usr/local/zeebe/data)"]; then
+            /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID} && echo "Restoration complete."
+          else
+            echo "ERROR: Could not delete zeebe data" >&2
+            exit 1
+          fi
         env:
         - name: ZEEBE_RESTORE_FROM_BACKUP_ID
           valueFrom:

--- a/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-1.yaml
+++ b/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-1.yaml
@@ -11,12 +11,11 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
-          ls -laR /usr/local/zeebe/data;
-          rm -rf /usr/local/zeebe/data/* /usr/local/zeebe/data/.*;
+          ls -laR /usr/local/zeebe/data
+          rm -rf /usr/local/zeebe/data/{*,.*}
           echo "Starting restoration process..."
-          ls -laR /usr/local/zeebe/data;
-          /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID}
-          echo "Restoration complete."
+          ls -laR /usr/local/zeebe/data
+          /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID} && echo "Restoration complete."
         env:
         - name: ZEEBE_RESTORE_FROM_BACKUP_ID
           valueFrom:
@@ -48,9 +47,6 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /usr/local/zeebe/data
-        securityContext:
-          runAsUser: 1000
-          runAsNonRoot: true
       securityContext:
         fsGroup: 1000 
       volumes:

--- a/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-1.yaml
+++ b/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-1.yaml
@@ -11,11 +11,12 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
+          #!/bin/bash
           ls -lAR /usr/local/zeebe/data
           rm -rf /usr/local/zeebe/data/{*,.*}
           echo "Starting restoration process..."
-          if [-z "$(ls -A /usr/local/zeebe/data)"]; then
-            /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID} && echo "Restoration complete."
+          if [ -z "$(ls -A /usr/local/zeebe/data)" ]; then
+            /usr/local/zeebe/bin/restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}" && echo "Restoration complete."
           else
             echo "ERROR: Could not delete zeebe data" >&2
             exit 1

--- a/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-2.yaml
+++ b/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-2.yaml
@@ -11,11 +11,15 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
-          ls -laR /usr/local/zeebe/data
+          ls -lAR /usr/local/zeebe/data
           rm -rf /usr/local/zeebe/data/{*,.*}
           echo "Starting restoration process..."
-          ls -laR /usr/local/zeebe/data
-          /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID} && echo "Restoration complete."
+          if [-z "$(ls -A /usr/local/zeebe/data)"]; then
+            /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID} && echo "Restoration complete."
+          else
+            echo "ERROR: Could not delete zeebe data" >&2
+            exit 1
+          fi
         env:
         - name: ZEEBE_RESTORE_FROM_BACKUP_ID
           valueFrom:

--- a/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-2.yaml
+++ b/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-2.yaml
@@ -11,12 +11,11 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
-          ls -laR /usr/local/zeebe/data;
-          rm -rf /usr/local/zeebe/data/* /usr/local/zeebe/data/.*;
+          ls -laR /usr/local/zeebe/data
+          rm -rf /usr/local/zeebe/data/{*,.*}
           echo "Starting restoration process..."
-          ls -laR /usr/local/zeebe/data;
-          /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID}
-          echo "Restoration complete."
+          ls -laR /usr/local/zeebe/data
+          /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID} && echo "Restoration complete."
         env:
         - name: ZEEBE_RESTORE_FROM_BACKUP_ID
           valueFrom:
@@ -48,9 +47,6 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /usr/local/zeebe/data
-        securityContext:
-          runAsUser: 1000
-          runAsNonRoot: true
       securityContext:
         fsGroup: 1000 
       volumes:

--- a/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-2.yaml
+++ b/03 - Lab 3 - Backup and Restore/restore/zeebe-restore-job-2.yaml
@@ -11,11 +11,12 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
+          #!/bin/bash
           ls -lAR /usr/local/zeebe/data
           rm -rf /usr/local/zeebe/data/{*,.*}
           echo "Starting restoration process..."
-          if [-z "$(ls -A /usr/local/zeebe/data)"]; then
-            /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID} && echo "Restoration complete."
+          if [ -z "$(ls -A /usr/local/zeebe/data)" ]; then
+            /usr/local/zeebe/bin/restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}" && echo "Restoration complete."
           else
             echo "ERROR: Could not delete zeebe data" >&2
             exit 1


### PR DESCRIPTION
- include rudimentary error handling
  - use `set -e` and `set -eo pipefail` if appropriate
  - use `&&` in other cases
  - use `--fail` for curl commands
- fix permission issue with zeebe backup jobs

closes #47 

This is just an initial step towards more resilient scripts, see https://mywiki.wooledge.org/BashFAQ/105